### PR TITLE
Add the primary attribute to the API

### DIFF
--- a/go-wolfram.go
+++ b/go-wolfram.go
@@ -166,6 +166,9 @@ type Pod struct {
 	//data it holds.
 	Scanner string `json:"scanner"`
 
+	//Marks the pod that displays the closest thing to a simple "answer" that Wolfram|Alpha can provide
+	Primary    bool   `json:"primary,omitempty"`
+
 	//Not documented currently
 	ID         string `json:"id"`
 	Position   int    `json:"position"`


### PR DESCRIPTION
Following the documentation for the field:

```Primary Result Tagging
Although Wolfram|Alpha returns many pods for most queries, there is sometimes the notion of a "primary result" for a given query. This is especially true for queries that correspond to Wolfram Language computations (e.g. "2+2") or simple data lookups (e.g. "France GDP"). If you are looking to display the closest thing to a simple "answer" that Wolfram|Alpha can provide, you can look for pods tagged as primary results via the primary=true attribute. Here is an example—the "Result" pod from the query "France GDP":

 <pod title="Result" scanner="Data" id="Result" position="200" error="false" numsubpods="1" primary="true">
  <subpod title="">
    <plaintext>
      $2.829 trillion per year (world rank: 6th) (2014 estimate)
    </plaintext>
    <img src= ... />
</subpod>
</pod>
Primary result tagging is a relatively new feature in Wolfram|Alpha, and many queries do not have a primary result, often because it is not meaningful for that query.
```

Source: https://products.wolframalpha.com/api/documentation/ (Primary Result Tagging)